### PR TITLE
Update ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,7 +3,7 @@
 inventory = inventory.yml
 interpreter_python = python3
 roles_path = .ansible/roles
-collections_paths = .ansible/collections
+collections_path = .ansible/collections
 callback_enabled = profile_tasks
 retry_files_enabled = False
 host_key_checking = False


### PR DESCRIPTION
The collections_paths configuration in your ansible.cfg file is deprecated because it does not follow the singular naming convention