### PR TITLE
Update ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -8,7 +8,8 @@ callback_enabled = profile_tasks
 retry_files_enabled = False
 host_key_checking = False
 # Use the YAML callback plugin.
-stdout_callback = yaml
+stdout_callback = default
+callback_result_format = yaml
 # Use the stdout_callback when running ad-hoc commands.
 bin_ansible_callbacks = True
 # needed on Debian server


### PR DESCRIPTION
The community.general.yaml callback plugin has been deprecated and replaced by the result_format=yaml option in the ansible.builtin.default callback plugin. This change was introduced in Ansible Core 2.13, and the deprecated plugin will be removed in community.general version 13.0.0.