### PR TITLE
Update configuration.yml.j2

### DIFF
--- a/roles/authelia/templates/configuration.yml.j2
+++ b/roles/authelia/templates/configuration.yml.j2
@@ -41,7 +41,12 @@ session:
   secret: {{ session_secret }}
   expiration: 3600  # 1 hour
   inactivity: 300  # 5 minutes
-  domain: {{ root_host }}  # Should match whatever your root protected domain is
+  domains:
+    - "{{ authelia_host }}"
+    - "{{ wireguard_host }}"
+{% if enable_adguard_unbound_doh %}
+    - "{{ adguard_host }}"
+{% endif %}
 
   redis:
     host: redis


### PR DESCRIPTION
- Replaced the deprecated 'session.domain' option with the new multi-domain configuration under 'session.domains'.
- Ensured compatibility with Authelia v4.38.x by aligning configuration with the latest standards.
- Removed outdated keys to prevent future warnings and ensure readiness for Authelia v5.0.0.